### PR TITLE
feat(util): add revert and revert-layer to CSS-wide keywords.

### DIFF
--- a/raffia/src/util.rs
+++ b/raffia/src/util.rs
@@ -7,6 +7,8 @@ pub fn is_css_wide_keyword(s: &str) -> bool {
     s.eq_ignore_ascii_case("initial")
         || s.eq_ignore_ascii_case("inherit")
         || s.eq_ignore_ascii_case("unset")
+        || s.eq_ignore_ascii_case("revert")
+        || s.eq_ignore_ascii_case("revert-layer")
 }
 
 pub trait LastOfNonEmpty<T> {


### PR DESCRIPTION
Fixes: https://github.com/w3c/csswg-drafts/issues/7439